### PR TITLE
Harden admin seeding, add logout endpoint, and frontend .env example

### DIFF
--- a/Back-End/src/main/java/com/example/controller/AuthController.java
+++ b/Back-End/src/main/java/com/example/controller/AuthController.java
@@ -87,4 +87,9 @@ public class AuthController {
                     .body("An error occurred during registration");
         }
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8080


### PR DESCRIPTION
### Motivation
- Prevent accidental creation of default admin accounts by requiring explicit configuration to enable seeding.
- Document the admin-seed settings so operators can safely opt-in and supply credentials.
- Align backend API surface with frontend expectations for logout and provide a frontend env example for API base URL configuration.

### Description
- Gate admin user seeding behind `app.seed-admin.enabled` and require `app.seed-admin.username`, `app.seed-admin.email`, and `app.seed-admin.password` in `Back-End/src/main/java/com/example/config/DataInitializer.java` so seeding runs only when explicitly configured.
- Add `app.seed-admin` examples to `Back-End/src/main/resources/application.yml.example` documenting the new settings and defaulting `enabled` to `false`.
- Add a frontend environment example `frontend/.env.example` with `REACT_APP_API_URL=http://localhost:8080` to standardize the API base URL configuration.
- Add a no-op `POST /api/auth/logout` endpoint in `Back-End/src/main/java/com/example/controller/AuthController.java` that returns `204 No Content` to match frontend logout calls.

### Testing
- No automated tests were executed for these changes (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c6966b98832dba54f8dfcd484a16)